### PR TITLE
Production-ize Google Sign-in

### DIFF
--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -27,8 +27,7 @@ export default NextAuth({
       clientSecret: process.env.GOOGLE_CLIENT_SECRET as string,
       authorization: {
         params: {
-          scope:
-            'https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/calendar.events',
+          scope: 'openid profile email',
         },
       },
     }),


### PR DESCRIPTION
Remove access requests to google calendar for now, as they're sensitive and make review hard to pass, especially as we haven't actually built the integration yet.